### PR TITLE
Küçük pencerelerde #main-header 'ın kısa kalması probleminin çözülmesi

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
                     <!-- Tagline -->
                     <div class="tagline">
                         <h6 class="tagline__date">08 Ekim 2016 - ANKARA</h6>
-                        <img class="logo" src="images/logo.jpg" alt="Webend">
+                        <img class="logo img-responsive" src="images/logo.jpg" alt="Webend">
                         <h3 class="tagline__sub-title">BACKEND KONFERANSI</h3>
                         <p class="tagline__description">
                            Backend dillerini tecrübeli geliştiricilerinden dinlemek için <em>8&nbsp;Ekim&nbsp;Cumartesi</em> günü <em>Ankara, ODTÜ'de</em> buluşuyoruz.

--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@
                         Seçkin geliştiricilerin konuşma yapacağı bu eşsiz etkinliğe katılmak için acele et.
                     </p>
                     <!-- Count -->
-                    <div class="countdown-area">
+                    <div class="countdown-area hidden-xs hidden-sm">
                         <div class="count count-month"></div>
                         <div class="count count-day"></div>
                         <div class="count count-hour"></div>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
             <!-- Title -->
             <h2 class="section-title">
                 <span class="main-text">NEDEN</span>
-                <span class="shadow-text">NEDEN</span>
+                <span class="shadow-text hidden-xs hidden-sm">NEDEN</span>
             </h2>
 
             <!-- Content -->
@@ -121,7 +121,7 @@
             <!-- Title -->
             <h2 class="section-title">
                 <span class="main-text">KONUŞMACILAR</span>
-                <span class="shadow-text">KONUŞMACILAR</span>
+                <span class="shadow-text hidden-xs hidden-sm">KONUŞMACILAR</span>
             </h2>
 
             <!-- Content -->
@@ -200,7 +200,7 @@
             <!-- Title -->
             <h2 class="section-title">
                 <span class="main-text">PROGRAM</span>
-                <span class="shadow-text">PROGRAM</span>
+                <span class="shadow-text hidden-xs hidden-sm">PROGRAM</span>
             </h2>
 
             <!-- Content -->
@@ -300,7 +300,7 @@
             <!-- Title -->
             <h2 class="section-title">
                 <span class="main-text">MEKAN</span>
-                <span class="shadow-text">MEKAN</span>
+                <span class="shadow-text hidden-xs hidden-sm">MEKAN</span>
             </h2>
 
             <!-- Content -->
@@ -327,7 +327,7 @@
             <!-- Title -->
             <h2 class="section-title">
                 <span class="main-text">SPONSORLUK</span>
-                <span class="shadow-text">SPONSORLUK</span>
+                <span class="shadow-text hidden-xs hidden-sm">SPONSORLUK</span>
             </h2>
 
             <!-- Content -->

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,14 @@
 $(document).ready(function(){
 
     // --- HEADER
-    var WH = $(window).height();
-    $('#main-header').height(WH);
+    // get header's content height to define min-height
+    var lastHeaderElement = document.getElementsByClassName("scroll-down")[0];
+    var lastHeaderElementPosition = lastHeaderElement.getBoundingClientRect();
+    var minHeight = lastHeaderElementPosition.bottom + 20;
+    var windowHeight = $(window).height();
+    var newHeight = windowHeight;
+    if(windowHeight<minHeight) newHeight = minHeight;
+    $('#main-header').height(newHeight);
 
 
     // --- COUNTDOWN


### PR DESCRIPTION
Sayfa yüklendiğinde #main-header divinin yüksekliği direkt pencere yüksekliğine eşitleniyordu. Özellikle mobil cihazlarda pencere yüksekliği, içeriğin ihtiyaç duyduğu alandan kısa olduğu için sayfa yüklendiğinde üst kısım çok kısa kalabiliyordu.

Bu güncelleme ile öncelikle #main-header divi içindeki son elementin (.scroll-down) konumu bulunur, bu konum bilgisine göre içerik için en az ne kadar alan ayrılması gerektiği belirlenir.

Pencere yüksekliği, asgari yükseklikten düşük kalırsa; #main-header kutusu pencere yüksekliği yerine asgari yüksekliğe göre tekrar boyutlandırılır.
